### PR TITLE
Adding lighthouse ci action that sends its results to Sentinel

### DIFF
--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -23,10 +23,8 @@ jobs:
         id: get_json_file 
         run: echo "file_name=$(jq -c '.[].jsonPath' <<< '${{steps.lhci_action.outputs.manifest}}' | sed -r 's/"//g')" >> $GITHUB_OUTPUT
 
-      - name: get direcotry listing
-        run: |
-          ls '${{steps.lhci_action.outputs.resultsPath}}'
-          cat '${{ steps.get_json_file.outputs.file_name }}'
+      - name: get report contents 
+        run: cat '${{ steps.get_json_file.outputs.file_name }}'
 
       - name: Send data to sentinel action
         id: sentinel-data-forward

--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -12,19 +12,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Lighthouse CI Action 
-        id: LHCIAction 
-        uses: treosh/lighthouse-ci-action@v9 
+      - name: Lighthouse CI Action
+        id: lhci_action
+        uses: treosh/lighthouse-ci-action@v9
         with:
          urls: |
           https://secret.cdssandbox.xyz/
+      - name: Format input file
+        id: format_file
+        run: echo "file_name=$(jq -c '.[].jsonPath' <<< '${{steps.lhci_action.outputs.manifest}}')" >> $GITHUB_OUTPUT
 
       - name: Send data to sentinel action
-        id: sentinel-data-forward 
+        id: sentinel-data-forward
         uses: cds-snc/sentinel-forward-data-action@main
         with:
-         file_name: ${{ steps.LHCIAction.outputs.manifest.jsonPath }}
-         input_data: '{ "links": ${{steps.LHCIAction.outputs.links}}, "manifest": ${{steps.LHCIAction.outputs.manifest}} }'
+         file_name: ${{ steps.lhci_action.outputs.file_name }}
+         input_data: '{ "links": ${{steps.lhci_action.outputs.links}}, "manifest": ${{steps.lhci_action.outputs.manifest}} }'
          log_type: "TestData_CL"
          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
          log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}

--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -18,9 +18,14 @@ jobs:
         with:
          urls: |
           https://secret.cdssandbox.xyz/
+
       - name: Get json file 
         id: get_json_file 
         run: echo "file_name=$(jq -c '.[].jsonPath' <<< '${{steps.lhci_action.outputs.manifest}}')" >> $GITHUB_OUTPUT
+
+      - name: get direcotry listing
+        run: |
+          ls '${{steps.lhci_action.outputs.resultsPath}}'
 
       - name: Send data to sentinel action
         id: sentinel-data-forward

--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -21,9 +21,7 @@ jobs:
 
       - name: Get json file 
         id: get_json_file 
-        run: |
-          echo '${{steps.lhci_action.outputs.manifest}}' | sed -r 's/"//g'
-          echo "file_name=$(jq -c '.[].jsonPath' <<< '${{steps.lhci_action.outputs.manifest}}')" >> $GITHUB_OUTPUT
+        run: echo "file_name=$(jq -c '.[].jsonPath' <<< '${{steps.lhci_action.outputs.manifest}}' | sed -r 's/"//g')" >> $GITHUB_OUTPUT
 
       - name: get direcotry listing
         run: |

--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -1,0 +1,29 @@
+name: Use Lighthouse CI Github action and send results to Sentinel
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  lighthouse-ci-action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Lighthouse CI Action 
+        id: LHCIAction 
+        uses: treosh/lighthouse-ci-action@v9 
+        with:
+         urls: |
+          https://secret.cdssandbox.xyz/
+
+      - name: Send data to sentinel action
+        id: sentinel-data-forward 
+        uses: cds-snc/sentinel-forward-data-action@main
+        with:
+         input_data: '{ "links": ${{steps.LHCIAction.outputs.links}}, "manifest": ${{steps.LHCIAction.outputs.manifest}} }'
+         log_type: "TestData_CL"
+         log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}
+         log_analytics_workspace_key: ${{ secrets.LOG_ANALYTICS_WORKSPACE_KEY }}

--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -26,6 +26,7 @@ jobs:
       - name: get direcotry listing
         run: |
           ls '${{steps.lhci_action.outputs.resultsPath}}'
+          cat '${{ steps.get_json_file.outputs.file_name }}'
 
       - name: Send data to sentinel action
         id: sentinel-data-forward

--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -21,7 +21,9 @@ jobs:
 
       - name: Get json file 
         id: get_json_file 
-        run: echo "file_name=$(jq -c '.[].jsonPath' <<< '${{steps.lhci_action.outputs.manifest}}')" >> $GITHUB_OUTPUT
+        run: |
+          echo '${{steps.lhci_action.outputs.manifest}}' | sed -r 's/"//g'
+          echo "file_name=$(jq -c '.[].jsonPath' <<< '${{steps.lhci_action.outputs.manifest}}')" >> $GITHUB_OUTPUT
 
       - name: get direcotry listing
         run: |

--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -18,15 +18,15 @@ jobs:
         with:
          urls: |
           https://secret.cdssandbox.xyz/
-      - name: Format input file
-        id: format_file
+      - name: Get json file 
+        id: get_json_file 
         run: echo "file_name=$(jq -c '.[].jsonPath' <<< '${{steps.lhci_action.outputs.manifest}}')" >> $GITHUB_OUTPUT
 
       - name: Send data to sentinel action
         id: sentinel-data-forward
         uses: cds-snc/sentinel-forward-data-action@main
         with:
-         file_name: ${{ steps.lhci_action.outputs.file_name }}
+         file_name: ${{ steps.get_json_file.outputs.file_name }}
          input_data: '{ "links": ${{steps.lhci_action.outputs.links}}, "manifest": ${{steps.lhci_action.outputs.manifest}} }'
          log_type: "TestData_CL"
          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}

--- a/.github/workflows/lighthouse_ci_sentinel_action.yml
+++ b/.github/workflows/lighthouse_ci_sentinel_action.yml
@@ -23,6 +23,7 @@ jobs:
         id: sentinel-data-forward 
         uses: cds-snc/sentinel-forward-data-action@main
         with:
+         file_name: ${{ steps.LHCIAction.outputs.manifest.jsonPath }}
          input_data: '{ "links": ${{steps.LHCIAction.outputs.links}}, "manifest": ${{steps.LHCIAction.outputs.manifest}} }'
          log_type: "TestData_CL"
          log_analytics_workspace_id: ${{ secrets.LOG_ANALYTICS_WORKSPACE_ID }}


### PR DESCRIPTION
# Summary 

DRAFT - PR to test out Lighthouse CI Action. First we run the Lighthouse CI action and the result is sent to Sentinel using the sentinel data forward action. 