### PR TITLE
add id-token:write for OIDC

### DIFF
--- a/.github/workflows/ossf-scorecard.yml
+++ b/.github/workflows/ossf-scorecard.yml
@@ -14,6 +14,7 @@ permissions:
   pull-requests: read
   checks: read
   actions: read
+  id-token: write
 
 jobs:
   analysis:

--- a/README.md
+++ b/README.md
@@ -13,9 +13,11 @@ This action supports two APIs:
 
 The action performs its own GitHub Actions OIDC token exchange internally — no separate `azure/login` step is needed.
 
+> **Required:** the calling workflow must grant `id-token: write` permission. Without it, the GitHub OIDC token request env vars are not injected into the action's container and authentication will fail with `DefaultAzureCredential failed to retrieve a token`.
+
 ```yaml
 permissions:
-  id-token: write
+  id-token: write  # required for OIDC federated credentials
 
 steps:
   - name: "Post results to Sentinel"


### PR DESCRIPTION
# Summary | Résumé

This PR adds the write access for id-token in the GH action so it can authenticate with OIDC